### PR TITLE
Fix CSS syntax

### DIFF
--- a/rainbow.css
+++ b/rainbow.css
@@ -1,63 +1,32 @@
 /**
  * @name RainbowGlow
  * @author Wolfÿ
- * @version 1.0.0
+ * @version 1.0.1
  * @description Makes the Avatar have a RainbowGlow when someone is speaking
  * @invite avia
  * @source https://github.com/MEWPASCO/rainbowglow-avatars
  * @website https://www.avariaxyz.win/
  */
 
-/* Rainbow glow around Avatars in VC */
-#app-mount
-  /* Avatars in the VC when in Chat wiew - Server */
-  .avatarSpeaking__07f91 {
-    -webkit-box-shadow: inset 0 0 0 2px #0ff !important;
-    box-shadow: inset 0 0 0 2px #0ff !important;
-    -webkit-animation: rainbow 3s infinite linear !important;
-    animation: rainbow 3s infinite linear !important;
-  }
+/* Rainbow glow around avatars in VC */
+#app-mount .avatarSpeaking__07f91,
+#app-mount .avatarSpeaking__44b0c,
+#app-mount .speaking__2f4f7,
+#app-mount .speaking__68617,
+#app-mount .speaking__f910d0 {
+  -webkit-box-shadow: inset 0 0 0 2px #0ff !important;
+  box-shadow: inset 0 0 0 2px #0ff !important;
+  -webkit-animation: rainbow 3s infinite linear !important;
+  animation: rainbow 3s infinite linear !important;
+}
 
-  /* Own useravatar in the bottom left - Everywhere */
-  .avatarSpeaking__44b0c {
-    -webkit-box-shadow: inset 0 0 0 2px #0ff !important;
-    box-shadow: inset 0 0 0 2px #0ff !important;
-    -webkit-animation: rainbow 3s infinite linear !important;
-    animation: rainbow 3s infinite linear !important;
+@keyframes rainbow {
+  0% {
+    -webkit-filter: hue-rotate(0deg);
+    filter: hue-rotate(0deg);
   }
-
-  /* Big boxes when VC is in focus - Everywhere */
-  .speaking__2f4f7 {
-    -webkit-box-shadow: inset 0 0 0 2px #0ff !important;
-    box-shadow: inset 0 0 0 2px #0ff !important;
-    -webkit-animation: rainbow 3s infinite linear !important;
-    animation: rainbow 3s infinite linear !important;
+  100% {
+    -webkit-filter: hue-rotate(360deg);
+    filter: hue-rotate(360deg);
   }
-
-  /* Small avatar below "Voice connected" if enabled - Everywhere */
-  .speaking__68617 {
-    -webkit-box-shadow: inset 0 0 0 2px #0ff !important;
-    box-shadow: inset 0 0 0 2px #0ff !important;
-    -webkit-animation: rainbow 3s infinite linear !important;
-    animation: rainbow 3s infinite linear !important;
-  }
-
-  /* Avatars in private/group call - DMs */
-  .speaking_f910d0 {
-    -webkit-box-shadow: inset 0 0 0 2px #0ff !important;
-    box-shadow: inset 0 0 0 2px #0ff !important;
-    -webkit-animation: rainbow 3s infinite linear !important;
-    animation: rainbow 3s infinite linear !important;
-  }
-
-  /* Animation */
-  @keyframes rainbow {
-    0% {
-      -webkit-filter: hue-rotate(0deg);
-      filter: hue-rotate(0deg);
-    }
-    100% {
-      -webkit-filter: hue-rotate(360deg);
-      filter: hue-rotate(360deg);
-    }
 }


### PR DESCRIPTION
## Summary
- fix invalid CSS syntax by flattening selectors
- bump theme version to 1.0.1

## Testing
- `npx csslint rainbow.css` *(fails: missing network access)*

------
https://chatgpt.com/codex/tasks/task_e_684d6be0f514832eb65e84ce4bce13e3